### PR TITLE
Update rules.mk

### DIFF
--- a/Software/QMKv2/rules.mk
+++ b/Software/QMKv2/rules.mk
@@ -9,7 +9,7 @@ MCU = atmega32u4
 #   QMK DFU      qmk-dfu
 #   ATmega32A    bootloadHID
 #   ATmega328P   USBasp
-BOOTLOADER = caterina
+BOOTLOADER = atmel-dfu
 
 # Build Options
 #   change to "no" to disable the options, or define them in the Makefile in


### PR DESCRIPTION
Updating MK file to select correct bootloader.     This will allow the  qmk flash command to work by default.